### PR TITLE
fix barrier transaction bug

### DIFF
--- a/src/DtmMongoBarrier/MongoBranchBarrier.cs
+++ b/src/DtmMongoBarrier/MongoBranchBarrier.cs
@@ -145,7 +145,7 @@ namespace DtmMongoBarrier
             {
                 try
                 {
-                    await barrier.InsertOneAsync(new DtmBarrierDocument
+                    await barrier.InsertOneAsync(session,new DtmBarrierDocument
                     {
                         TransType = bb.TransType,
                         GId = bb.Gid,


### PR DESCRIPTION
If you need to execute MongoDB commands within a transaction, you need to explicitly pass the session. @catcherwong 