### PR TITLE
build(tests): upgrade all test projects to .NET 8.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
+            8.0.x
             7.0.x
             6.0.x
             3.1.x
@@ -45,11 +46,11 @@ jobs:
       #     dotnet test --framework=net6.0 tests/Dtmgrpc.Tests/Dtmgrpc.Tests.csproj --collect:"XPlat Code Coverage"
       #     dotnet test --framework=net6.0 tests/Dtmworkflow.Tests/Dtmworkflow.Tests.csproj --collect:"XPlat Code Coverage"
 
-      - name: Run tests on net7.0
+      - name: Run tests on net8.0
         run: |
-          dotnet test --framework=net7.0 tests/Dtmcli.Tests/Dtmcli.Tests.csproj --collect:"XPlat Code Coverage"
-          dotnet test --framework=net7.0 tests/Dtmgrpc.Tests/Dtmgrpc.Tests.csproj --collect:"XPlat Code Coverage"
-          dotnet test --framework=net7.0 tests/Dtmworkflow.Tests/Dtmworkflow.Tests.csproj --collect:"XPlat Code Coverage"
+          dotnet test --framework=net8.0 tests/Dtmcli.Tests/Dtmcli.Tests.csproj --collect:"XPlat Code Coverage"
+          dotnet test --framework=net8.0 tests/Dtmgrpc.Tests/Dtmgrpc.Tests.csproj --collect:"XPlat Code Coverage"
+          dotnet test --framework=net8.0 tests/Dtmworkflow.Tests/Dtmworkflow.Tests.csproj --collect:"XPlat Code Coverage"
 
       - name: Prepare Codecov
         continue-on-error: true

--- a/.github/workflows/release_stable.yml
+++ b/.github/workflows/release_stable.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: 8.0.x
       - name: Build with dotnet
         run: |
           dotnet build --configuration Release --source https://api.nuget.org/v3/index.json src/Dtmcli/Dtmcli.csproj         

--- a/.github/workflows/release_unstable.yml
+++ b/.github/workflows/release_unstable.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: 8.0.x
       - name: Build with dotnet
         run: |
           dotnet build --configuration Release --source https://api.nuget.org/v3/index.json src/Dtmcli/Dtmcli.csproj        

--- a/samples/DtmOnDaprSample/DtmOnDaprSample.csproj
+++ b/samples/DtmOnDaprSample/DtmOnDaprSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<NoWarn>$(NoWarn);1591</NoWarn>
 		<UserSecretsId>8704306e-de65-470d-89b2-2b7b65ff3b64</UserSecretsId>

--- a/samples/DtmSample/DtmSample.csproj
+++ b/samples/DtmSample/DtmSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<NoWarn>$(NoWarn);1591</NoWarn>
 		<UserSecretsId>8704306e-de65-470d-89b2-2b7b65ff3b64</UserSecretsId>

--- a/tests/BusiGrpcService/BusiGrpcService.csproj
+++ b/tests/BusiGrpcService/BusiGrpcService.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <!--<Nullable>enable</Nullable>-->
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/tests/Dtmcli.Tests/Dtmcli.Tests.csproj
+++ b/tests/Dtmcli.Tests/Dtmcli.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>net7.0</TargetFrameworks>
+	<TargetFrameworks>net8.0</TargetFrameworks>
     <!--<Nullable>enable</Nullable>-->
 
     <IsPackable>false</IsPackable>

--- a/tests/Dtmgrpc.IntegrationTests/Dtmgrpc.IntegrationTests.csproj
+++ b/tests/Dtmgrpc.IntegrationTests/Dtmgrpc.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<!--<Nullable>enable</Nullable>-->
 
 		<IsPackable>false</IsPackable>

--- a/tests/Dtmgrpc.Tests/Dtmgrpc.Tests.csproj
+++ b/tests/Dtmgrpc.Tests/Dtmgrpc.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net7.0</TargetFrameworks>
+		<TargetFrameworks>net8.0</TargetFrameworks>
 
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>

--- a/tests/Dtmworkflow.Tests/Dtmworkflow.Tests.csproj
+++ b/tests/Dtmworkflow.Tests/Dtmworkflow.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 


### PR DESCRIPTION
- .NET 7 support  ended, upgrade to latest LTS .NET 8.   
    > [.NET 7 will reach End of Support on May 14, 2024 - .NET Blog](https://devblogs.microsoft.com/dotnet/dotnet-7-end-of-support/)
- Update github actions