### PR TITLE
fix(BranchBarrier): fix QueryPrepared method not return real insert exception

### DIFF
--- a/src/DtmCommon/Barrier/BranchBarrier.cs
+++ b/src/DtmCommon/Barrier/BranchBarrier.cs
@@ -179,21 +179,21 @@ namespace DtmCommon
 
         public async Task<string> QueryPrepared(DbConnection db)
         {
-            try
+            if (db == null) return "db is null";
+
+            (int _, Exception insertException) = await DbUtils.InsertBarrier(
+                db,
+                this.TransType,
+                this.Gid,
+                Constant.Barrier.MSG_BRANCHID,
+                Constant.TYPE_MSG,
+                Constant.Barrier.MSG_BARRIER_ID,
+                Constant.Barrier.MSG_BARRIER_REASON);
+
+            if (insertException != null)
             {
-                var tmp = await DbUtils.InsertBarrier(
-                    db,
-                    this.TransType,
-                    this.Gid,
-                    Constant.Barrier.MSG_BRANCHID,
-                    Constant.TYPE_MSG,
-                    Constant.Barrier.MSG_BARRIER_ID,
-                    Constant.Barrier.MSG_BARRIER_REASON);
-            }
-            catch (Exception ex)
-            {
-                Logger?.LogWarning(ex, "Insert Barrier error, gid={gid}", this.Gid);
-                return ex.Message;
+                Logger?.LogWarning(insertException, "Insert Barrier error, gid={gid}", this.Gid);
+                return insertException.Message;
             }
 
             var reason = string.Empty;


### PR DESCRIPTION
QueryPrepared调用的DbUtils.InsertBarrier里面有try了，返回插入行数+异常的元组，当插入遇到意料外的异常（如账号权现不能写），之前它还会往下走，导致reason.Equals出现null引用，虽然最终也是异常，但尽量返回真正的异常。

参考了go client的实现：
```
// QueryPrepared queries prepared data
func (bb *BranchBarrier) QueryPrepared(db *sql.DB) error {
	_, err := dtmimp.InsertBarrier(db, bb.TransType, bb.Gid, dtmimp.MsgDoBranch0, dtmimp.MsgDoOp, dtmimp.MsgDoBarrier1, dtmimp.OpRollback, bb.DBType, bb.BarrierTableName)
	var reason string
	if err == nil {
		sql := fmt.Sprintf("select reason from %s where gid=? and branch_id=? and op=? and barrier_id=?", dtmimp.BarrierTableName)
		sql = dtmimp.GetDBSpecial(bb.DBType).GetPlaceHoldSQL(sql)
		logger.Debugf("queryrow: %s", sql, bb.Gid, dtmimp.MsgDoBranch0, dtmimp.MsgDoOp, dtmimp.MsgDoBarrier1)
		err = db.QueryRow(sql, bb.Gid, dtmimp.MsgDoBranch0, dtmimp.MsgDoOp, dtmimp.MsgDoBarrier1).Scan(&reason)
	}
	if reason == dtmimp.OpRollback {
		return ErrFailure
	}
	return err
}
```