### PR TITLE
comments: update MsgTestController with dtm server compatibility note

### DIFF
--- a/samples/DtmSample/Controllers/MsgTestController.cs
+++ b/samples/DtmSample/Controllers/MsgTestController.cs
@@ -187,6 +187,22 @@ namespace DtmSample.Controllers
 
         /// <summary>
         /// MSG QueryPrepared(mssql)
+        /// 
+        /// tips: Starting with server v1.10, dtm server changed to use the http status code, but was compatible with the body returned by older versions
+        /// The http status code 200 with unrecognized body It will be as normal!
+        /// eg: v1.18.0 [dtm/client/dtmcli/utils.go · dtm-labs/dtm](https://github.com/dtm-labs/dtm/blob/v1.18.0/client/dtmcli/utils.go)
+        /// func HTTPResp2DtmError(resp *resty.Response) error {
+        /// code := resp.StatusCode()
+        ///     str := resp.String()
+        /// if code == http.StatusTooEarly || strings.Contains(str, ResultOngoing) {
+        ///     return ErrorMessage2Error(str, ErrOngoing)
+        /// } else if code == http.StatusConflict || strings.Contains(str, ResultFailure) {
+        ///     return ErrorMessage2Error(str, ErrFailure)
+        /// } else if code != http.StatusOK {
+        ///     return errors.New(str)
+        /// }
+        ///     return nil
+        /// }
         /// </summary>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>


### PR DESCRIPTION
在Sample示例的[HttpGet("msg-mssqlqueryprepared")]方法上增加注释，解释从dtm server v1.10开始对回调QueryPrepared返回状态的处理修改，以及提醒异常body内容但状态码是200时会被当成正常从而造成bug.

场景，MSG模式
前提： 读写屏障表的链接信息配置不正确
步骤：
1. 向dtm注册全局事务-prepared
2. 插入屏障表失败
3. 回调应用的http的QueryPrepared, 得到http200 body是"Object reference not set to an instance of an object."，通过HTTPResp2DtmError方法判定为无异常的正常，MSG事务被错误的commited了。