### PR TITLE
fix: update SQL Server barrier creation script

### DIFF
--- a/sqls/barrier.sqlserver.sql
+++ b/sqls/barrier.sqlserver.sql
@@ -1,9 +1,11 @@
 IF NOT EXISTS(SELECT * FROM sys.databases WHERE name = 'dtm_barrier')
 BEGIN
    CREATE DATABASE dtm_barrier
-   USE dtm_barrier
 END
 
+GO
+
+USE dtm_barrier
 GO
 
 IF EXISTS (SELECT * FROM sysobjects WHERE id = object_id(N'[dbo].[barrier]') and OBJECTPROPERTY(id, N'IsUserTable') = 1)  


### PR DESCRIPTION
fix NOT use the dtm_barrier database when the DB exist and table does NOT exist