### PR TITLE
bugfix(DtmSample): fix MsgMsSqlQueryPrepared return http status 200 with unrecognized error body.

### DIFF
--- a/samples/DtmSample/AppSettings.cs
+++ b/samples/DtmSample/AppSettings.cs
@@ -2,10 +2,15 @@
 {
     public class AppSettings
     {
+        public string DtmUrl { get; set; }
+    
         public string BusiUrl { get; set; }
 
         public string SqlBarrierConn { get; set; }
 
+
+        public string SqlBarrierErrorConn { get; set; }
+        
         public string MongoBarrierConn { get; set; }
     }
 }

--- a/samples/DtmSample/appsettings.json
+++ b/samples/DtmSample/appsettings.json
@@ -24,6 +24,7 @@
     "SqlDbType": "sqlserver",
     "BarrierSqlTableName": "dbo.barrier",
     "SqlBarrierConn": "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=dtm_barrier;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False",
+    "SqlBarrierErrorConn": "Data Source=.;Initial Catalog=dtm_barrier;User ID=sa;Password=my_error_password;Connect Timeout=30;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False",
     "MongoBarrierConn": "mongodb://localhost:27017"
   }
 }


### PR DESCRIPTION
tip: http status code 200 with unrecognized body will be as normal!  #83 

- Add OrString、String2DtmError、Result2HttpJson methods to Utils.cs
- Refactor Msg QueryPrepared sample, call new methods in Utils.cs