### PR TITLE
ci: update .NET SDK and DTM server versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,9 +21,6 @@ jobs:
         with:
           dotnet-version: |
             8.0.x
-            7.0.x
-            6.0.x
-            3.1.x
 
       - name: Show dotnet Version
         run: |

--- a/.github/workflows/build_and_it.yml
+++ b/.github/workflows/build_and_it.yml
@@ -32,10 +32,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Setup .NET SDK 7.0.x
+      - name: Setup .NET SDK 8.0.x
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: 8.0.x
 
       - name: Show dotnet Version
         run: |
@@ -47,8 +47,8 @@ jobs:
           mysql -h127.0.0.1 -uroot -p123456 < /home/runner/work/client-csharp/client-csharp/sqls/busi.mysql.sql
       - name: Setup DTM server
         run: |
-          wget https://github.com/dtm-labs/dtm/releases/download/v1.17.1/dtm_1.17.1_linux_amd64.tar.gz
-          tar -xvf dtm_1.17.1_linux_amd64.tar.gz
+          wget https://github.com/dtm-labs/dtm/releases/download/v1.18.0/dtm_1.18.0_linux_amd64.tar.gz
+          tar -xvf dtm_1.18.0_linux_amd64.tar.gz
           pwd
           mkdir /home/runner/work/client-csharp/client-csharp/logs
           nohup ./dtm > /home/runner/work/client-csharp/client-csharp/logs/dtm.log 2>&1 &
@@ -61,7 +61,7 @@ jobs:
       - name: Run Integration Tests
         run: |
           dotnet build tests/Dtmgrpc.IntegrationTests/Dtmgrpc.IntegrationTests.csproj 
-          dotnet test tests/Dtmgrpc.IntegrationTests/Dtmgrpc.IntegrationTests.csproj
+          dotnet test --framework=net8.0 tests/Dtmgrpc.IntegrationTests/Dtmgrpc.IntegrationTests.csproj
       - name: Upload logs
         if: always()
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
- Remove unused .NET SDK versions (7.0.x, 6.0.x,3.1.x) from build workflow
- Update .NET SDK version to 8.0.x in build_and_it workflow
- Update DTM server version from 1.17.1 to 1.18.0 in build_and_it workflow