### PR TITLE
ci: allow empty MySQL password

### DIFF
--- a/.github/workflows/build_and_it.yml
+++ b/.github/workflows/build_and_it.yml
@@ -24,7 +24,7 @@ jobs:
           --health-interval=10s
           --health-timeout=5s
           --health-retries=3 
-          -e MYSQL_ROOT_PASSWORD=123456
+          -e MYSQL_ALLOW_EMPTY_PASSWORD=1
           --entrypoint sh mysql:8.0 -c "exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password"
     strategy:
       matrix:
@@ -43,8 +43,8 @@ jobs:
           dotnet --list-runtimes
       - name: Create database
         run: |
-          mysql -h127.0.0.1 -uroot -p123456 < /home/runner/work/client-csharp/client-csharp/sqls/barrier.mysql.sql
-          mysql -h127.0.0.1 -uroot -p123456 < /home/runner/work/client-csharp/client-csharp/sqls/busi.mysql.sql
+          mysql -h127.0.0.1 -uroot < /home/runner/work/client-csharp/client-csharp/sqls/barrier.mysql.sql
+          mysql -h127.0.0.1 -uroot < /home/runner/work/client-csharp/client-csharp/sqls/busi.mysql.sql
       - name: Setup DTM server
         run: |
           wget https://github.com/dtm-labs/dtm/releases/download/v1.18.0/dtm_1.18.0_linux_amd64.tar.gz

--- a/samples/DtmOnDaprSample/appsettings.docker.json
+++ b/samples/DtmOnDaprSample/appsettings.docker.json
@@ -12,7 +12,7 @@
   "AppSettings": {
     "DtmUrl": "http://dtm:36789",
     "BusiUrl": "http://sample:9090/api",
-    "BarrierConn": "Server=db;port=3306;User ID=root;Password=123456;Database=dtm_barrier",
+    "BarrierConn": "Server=db;port=3306;User ID=root;Password=;Database=dtm_barrier",
     "MongoBarrierConn": "mongodb://mgdb:27017"
   }
 }

--- a/samples/DtmSample/appsettings.docker.json
+++ b/samples/DtmSample/appsettings.docker.json
@@ -13,7 +13,7 @@
     "DtmUrl": "http://dtm:36789",
     "DtmGrpcUrl": "http://dtm:36790",
     "BusiUrl": "http://sample:9090/api",
-    "BarrierConn": "Server=db;port=3306;User ID=root;Password=123456;Database=dtm_barrier",
+    "BarrierConn": "Server=db;port=3306;User ID=root;Password=;Database=dtm_barrier",
     "MongoBarrierConn": "mongodb://mgdb:27017"
   }
 }

--- a/tests/BusiGrpcService/Services/BusiApiService.cs
+++ b/tests/BusiGrpcService/Services/BusiApiService.cs
@@ -279,7 +279,7 @@ namespace BusiGrpcService.Services
             return new Empty();
         }
 
-        private MySqlConnection GetBarrierConn() => new("Server=localhost;port=3306;User ID=root;Password=123456;Database=dtm_barrier");
+        private MySqlConnection GetBarrierConn() => new("Server=localhost;port=3306;User ID=root;Password=;Database=dtm_barrier");
 
         private async Task<StackExchange.Redis.IDatabase> GetRedis()
         {

--- a/tests/Dtmgrpc.IntegrationTests/MsgGrpcTest.cs
+++ b/tests/Dtmgrpc.IntegrationTests/MsgGrpcTest.cs
@@ -111,7 +111,7 @@ namespace Dtmgrpc.IntegrationTests
 
         private static readonly int TransInUID = 2;
 
-        private MySqlConnection getBarrierMySqlConnection() => new("Server=localhost;port=3306;User ID=root;Password=123456;Database=dtm_barrier");
+        private MySqlConnection getBarrierMySqlConnection() => new("Server=localhost;port=3306;User ID=root;Password=;Database=dtm_barrier");
 
         private async Task LocalAdjustBalance(DbConnection conn, int uid, long amount, string result)
         {


### PR DESCRIPTION
老大哥go那边的测试mysql的密码是空的，本地频繁切换项目的集成测试有点繁琐，调整成跟go那边一致使用空密码