### PR TITLE
sample: sample for workflow ExecuteByQS（http）&& correct typo in WorkflowGlobalTransaction class name

### DIFF
--- a/samples/DtmSample/Controllers/WfTestController.cs
+++ b/samples/DtmSample/Controllers/WfTestController.cs
@@ -6,10 +6,12 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System;
+using System.IO;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
+using System.Text.Unicode;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -250,6 +252,85 @@ namespace DtmSample.Controllers
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Workflow Tcc Error");
+                return Ok(TransResponse.BuildFailureResponse());
+            }
+        }
+
+
+        private static readonly string wfNameForResume = "wfNameForResume";
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        [HttpPost("wf-crash")]
+        public async Task<IActionResult> Crash(CancellationToken cancellationToken)
+        {
+            if (!_globalTransaction.Exists(wfNameForResume))
+            {
+                _globalTransaction.Register(wfNameForResume, async (wf, data) =>
+                {
+                    var content = new ByteArrayContent(data);
+                    content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+                    var outClient = wf.NewBranch().NewRequest();
+                    await outClient.PostAsync(_settings.BusiUrl + "/TransOut", content);
+
+                    // the first branch succeed, then crashed, the dtm server will call back the flowing wf-call-back
+                    // manual stop application
+                    Environment.Exit(0);
+
+                    var inClient = wf.NewBranch().NewRequest();
+                    await inClient.PostAsync(_settings.BusiUrl + "/TransIn", content);
+
+                    return null;
+                });
+            }
+            
+            var req = JsonSerializer.Serialize(new TransRequest("1", -30));
+            await _globalTransaction.Execute(wfNameForResume, Guid.NewGuid().ToString("N"), Encoding.UTF8.GetBytes(req), true);
+
+            return Ok(TransResponse.BuildSucceedResponse());
+        }
+
+        [HttpPost("wf-resume")]
+        public async Task<IActionResult> WfResume(CancellationToken cancellationToken)
+        {
+            try
+            {
+                if (!_globalTransaction.Exists(wfNameForResume))
+                {
+                    // register again after manual crash by Environment.Exit(0);
+                    _globalTransaction.Register(wfNameForResume, async (wf, data) =>
+                    {
+                        var content = new ByteArrayContent(data);
+                        content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+                        var outClient = wf.NewBranch().NewRequest();
+                        await outClient.PostAsync(_settings.BusiUrl + "/TransOut", content);
+
+                        var inClient = wf.NewBranch().NewRequest();
+                        await inClient.PostAsync(_settings.BusiUrl + "/TransIn", content);
+
+                        return null;
+                    });
+                }
+
+                // prepared call ExecuteByQS
+                using var bodyMemoryStream = new MemoryStream();
+                await Request.Body.CopyToAsync(bodyMemoryStream, cancellationToken);
+                byte[] bytes = bodyMemoryStream.ToArray();
+                string body = Encoding.UTF8.GetString(bytes);
+                _logger.LogDebug($"body: {body}");
+
+                await _globalTransaction.ExecuteByQS(Request.Query, bodyMemoryStream.ToArray());
+
+                return Ok(TransResponse.BuildSucceedResponse());
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Workflow Error");
                 return Ok(TransResponse.BuildFailureResponse());
             }
         }

--- a/samples/DtmSample/Controllers/WfTestController.cs
+++ b/samples/DtmSample/Controllers/WfTestController.cs
@@ -23,10 +23,10 @@ namespace DtmSample.Controllers
     {
 
         private readonly ILogger<WfTestController> _logger;
-        private readonly WorlflowGlobalTransaction _globalTransaction;
+        private readonly WorkflowGlobalTransaction _globalTransaction;
         private readonly AppSettings _settings;
 
-        public WfTestController(ILogger<WfTestController> logger, IOptions<AppSettings> optionsAccs, WorlflowGlobalTransaction transaction)
+        public WfTestController(ILogger<WfTestController> logger, IOptions<AppSettings> optionsAccs, WorkflowGlobalTransaction transaction)
         {
             _logger = logger;
             _settings = optionsAccs.Value;

--- a/samples/DtmSample/Startup.cs
+++ b/samples/DtmSample/Startup.cs
@@ -29,7 +29,7 @@ namespace DtmSample
                 dtm.SqlDbType = Configuration.GetValue<string>("AppSettings:SqlDbType");
                 dtm.BarrierSqlTableName = Configuration.GetValue<string>("AppSettings:BarrierSqlTableName");
                 dtm.DtmGrpcUrl = Configuration.GetValue<string>("AppSettings:DtmGrpcUrl");
-                dtm.HttpCallback = "";
+                dtm.HttpCallback = $"{Configuration.GetValue<string>("AppSettings:BusiUrl")}/wf-resume";
                 dtm.GrpcCallback = "";
             });
 

--- a/src/Dtmworkflow/ServiceCollectionExtensions.cs
+++ b/src/Dtmworkflow/ServiceCollectionExtensions.cs
@@ -21,7 +21,7 @@ namespace Dtmworkflow
             services.AddDtmGrpc(setupAction);
 
             services.TryAddSingleton<IWorkflowFactory, WorkflowFactory>();
-            services.TryAddSingleton<WorlflowGlobalTransaction>();
+            services.TryAddSingleton<WorkflowGlobalTransaction>();
 
             return services;
         }
@@ -32,7 +32,7 @@ namespace Dtmworkflow
             services.AddDtmGrpc(configuration, sectionName);
 
             services.TryAddSingleton<IWorkflowFactory, WorkflowFactory>();
-            services.TryAddSingleton<WorlflowGlobalTransaction>();
+            services.TryAddSingleton<WorkflowGlobalTransaction>();
 
             return services;
         }

--- a/src/Dtmworkflow/WorkflowGlobalTransaction.cs
+++ b/src/Dtmworkflow/WorkflowGlobalTransaction.cs
@@ -6,17 +6,17 @@ using System.Threading.Tasks;
 
 namespace Dtmworkflow
 {
-    public class WorlflowGlobalTransaction
+    public class WorkflowGlobalTransaction
     {
         private readonly Dictionary<string, WfItem> _handlers;
         private readonly IWorkflowFactory _workflowFactory;
         private readonly ILogger _logger;
 
-        public WorlflowGlobalTransaction(IWorkflowFactory workflowFactory, ILoggerFactory loggerFactory)
+        public WorkflowGlobalTransaction(IWorkflowFactory workflowFactory, ILoggerFactory loggerFactory)
         {
             this._handlers = new Dictionary<string, WfItem>();
             this._workflowFactory = workflowFactory;
-            this._logger = loggerFactory.CreateLogger<WorlflowGlobalTransaction>();
+            this._logger = loggerFactory.CreateLogger<WorkflowGlobalTransaction>();
         }
 
         public async Task<byte[]> Execute(string name, string gid, byte[] data, bool isHttp = true)

--- a/src/Dtmworkflow/WorlflowGlobalTransaction.cs
+++ b/src/Dtmworkflow/WorlflowGlobalTransaction.cs
@@ -51,7 +51,7 @@ namespace Dtmworkflow
                 Custom = custom.ToList()
             });
         }
-
+        
 #if NET5_0_OR_GREATER
         public async Task ExecuteByQS(Microsoft.AspNetCore.Http.IQueryCollection query, byte[] body)
         {
@@ -61,5 +61,12 @@ namespace Dtmworkflow
             await Execute(op, gid, body, true);
         }
 #endif
+        
+        #if DEBUG // for sample only
+        public bool Exists(string name)
+        {
+            return this._handlers.ContainsKey(name);
+        }
+        #endif
     }
 }

--- a/tests/Dtmworkflow.Tests/WorkflowGlobalTransactionTest.cs
+++ b/tests/Dtmworkflow.Tests/WorkflowGlobalTransactionTest.cs
@@ -1,0 +1,38 @@
+using Dtmcli;
+using Dtmgrpc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Dtmworkflow.Tests;
+
+public class WorkflowGlobalTransactionTest
+{
+    #if DEBUG
+    [Fact]
+    public void Exists()
+    {
+        var factory = new Mock<IWorkflowFactory>();
+        var wf = new WorkflowGlobalTransaction(factory.Object, NullLoggerFactory.Instance);
+        
+        Assert.Throws<System.ArgumentNullException>(() => wf.Exists(null));
+        Assert.False(wf.Exists(string.Empty));
+        Assert.False(wf.Exists("my-wf1"));
+        Assert.False(wf.Exists("my-wf2"));
+        Assert.False(wf.Exists("my-wf3"));
+
+        wf.Register("my-wf1", (workflow, data) => null);
+        wf.Register("my-wf2", (workflow, data) => null);
+
+        Assert.Throws<System.ArgumentNullException>(() => wf.Exists(null));
+        Assert.False(wf.Exists(string.Empty));
+        Assert.True(wf.Exists("my-wf1"));
+        Assert.True(wf.Exists("my-wf2"));
+        Assert.False(wf.Exists("my-wf3"));
+        
+        var wf2 = new WorkflowGlobalTransaction(factory.Object, NullLoggerFactory.Instance);
+        Assert.False(wf2.Exists("my-wf1"));
+        Assert.False(wf2.Exists("my-wf2"));
+        Assert.False(wf2.Exists("my-wf3"));
+    }
+    #endif
+}

--- a/tests/Dtmworkflow.Tests/WorkflowHttpTests.cs
+++ b/tests/Dtmworkflow.Tests/WorkflowHttpTests.cs
@@ -27,7 +27,7 @@ namespace Dtmworkflow.Tests
 
             factory.Setup(x => x.NewWorkflow(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<bool>())).Returns(wf.Object);
 
-            var wfgt = new WorlflowGlobalTransaction(factory.Object, NullLoggerFactory.Instance);
+            var wfgt = new WorkflowGlobalTransaction(factory.Object, NullLoggerFactory.Instance);
 
             var wfName = nameof(Execute_Should_Succeed_When_PWF_Succeed);
             var gid = Guid.NewGuid().ToString("N");
@@ -56,7 +56,7 @@ namespace Dtmworkflow.Tests
 
             factory.Setup(x => x.NewWorkflow(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<bool>())).Returns(wf.Object);
 
-            var wfgt = new WorlflowGlobalTransaction(factory.Object, NullLoggerFactory.Instance);
+            var wfgt = new WorkflowGlobalTransaction(factory.Object, NullLoggerFactory.Instance);
 
             var wfName = nameof(Execute_Should_Throw_DtmFailureException_When_PWF_Failed);
             var gid = Guid.NewGuid().ToString("N");
@@ -90,7 +90,7 @@ namespace Dtmworkflow.Tests
 
             factory.Setup(x => x.NewWorkflow(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<bool>())).Returns(wf.Object);
 
-            var wfgt = new WorlflowGlobalTransaction(factory.Object, NullLoggerFactory.Instance);
+            var wfgt = new WorkflowGlobalTransaction(factory.Object, NullLoggerFactory.Instance);
 
             var wfName = nameof(Execute_Should_Succeed_When_PWF_Submitted_And_Progress_Not_Failed);
             var gid = Guid.NewGuid().ToString("N");
@@ -125,7 +125,7 @@ namespace Dtmworkflow.Tests
 
             factory.Setup(x => x.NewWorkflow(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<bool>())).Returns(wf.Object);
 
-            var wfgt = new WorlflowGlobalTransaction(factory.Object, NullLoggerFactory.Instance);
+            var wfgt = new WorkflowGlobalTransaction(factory.Object, NullLoggerFactory.Instance);
 
             var wfName = nameof(Execute_Should_ThrowException_When_WfFunc2_ThrowException);
             var gid = Guid.NewGuid().ToString("N");
@@ -159,7 +159,7 @@ namespace Dtmworkflow.Tests
 
             factory.Setup(x => x.NewWorkflow(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<bool>())).Returns(wf.Object);
 
-            var wfgt = new WorlflowGlobalTransaction(factory.Object, NullLoggerFactory.Instance);
+            var wfgt = new WorkflowGlobalTransaction(factory.Object, NullLoggerFactory.Instance);
 
             var wfName = nameof(Execute_Should_Return_Null_When_WfFunc2_ThrowDtmFailureException);
             var gid = Guid.NewGuid().ToString("N");
@@ -192,7 +192,7 @@ namespace Dtmworkflow.Tests
            
             factory.Setup(x => x.NewWorkflow(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<bool>())).Returns(wf.Object);
 
-            var wfgt = new WorlflowGlobalTransaction(factory.Object, NullLoggerFactory.Instance);
+            var wfgt = new WorkflowGlobalTransaction(factory.Object, NullLoggerFactory.Instance);
 
             var wfName = nameof(Rollback_Should_Be_Executed);
             var gid = Guid.NewGuid().ToString("N");
@@ -232,7 +232,7 @@ namespace Dtmworkflow.Tests
 
             factory.Setup(x => x.NewWorkflow(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<bool>())).Returns(wf.Object);
 
-            var wfgt = new WorlflowGlobalTransaction(factory.Object, NullLoggerFactory.Instance);
+            var wfgt = new WorkflowGlobalTransaction(factory.Object, NullLoggerFactory.Instance);
 
             var wfName = nameof(Commit_Should_Be_Executed);
             var gid = Guid.NewGuid().ToString("N");


### PR DESCRIPTION
1. sample for workflow ExecuteByQS（http）
    - Implement wf-crash endpoint to simulate workflow crash
    - Implement wf-resume endpoint for workflow http callback
    - Modify WorlflowGlobalTransaction.cs to add Exists method for debug only.
2. By the way, correct typo in WorkflowGlobalTransaction class name, rename WorlflowGlobalTransaction to WorkflowGlobalTransaction.