### PR TITLE
bugfix: add tests for workflow return values and fix null handling

### DIFF
--- a/samples/DtmSample/Controllers/WfTestController.cs
+++ b/samples/DtmSample/Controllers/WfTestController.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System;
 using System.IO;
+using System.Diagnostics;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -14,6 +15,7 @@ using System.Text.Json;
 using System.Text.Unicode;
 using System.Threading;
 using System.Threading.Tasks;
+using Exception = System.Exception;
 
 namespace DtmSample.Controllers
 {
@@ -252,85 +254,6 @@ namespace DtmSample.Controllers
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Workflow Tcc Error");
-                return Ok(TransResponse.BuildFailureResponse());
-            }
-        }
-
-
-        private static readonly string wfNameForResume = "wfNameForResume";
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
-        [HttpPost("wf-crash")]
-        public async Task<IActionResult> Crash(CancellationToken cancellationToken)
-        {
-            if (!_globalTransaction.Exists(wfNameForResume))
-            {
-                _globalTransaction.Register(wfNameForResume, async (wf, data) =>
-                {
-                    var content = new ByteArrayContent(data);
-                    content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
-
-                    var outClient = wf.NewBranch().NewRequest();
-                    await outClient.PostAsync(_settings.BusiUrl + "/TransOut", content);
-
-                    // the first branch succeed, then crashed, the dtm server will call back the flowing wf-call-back
-                    // manual stop application
-                    Environment.Exit(0);
-
-                    var inClient = wf.NewBranch().NewRequest();
-                    await inClient.PostAsync(_settings.BusiUrl + "/TransIn", content);
-
-                    return null;
-                });
-            }
-            
-            var req = JsonSerializer.Serialize(new TransRequest("1", -30));
-            await _globalTransaction.Execute(wfNameForResume, Guid.NewGuid().ToString("N"), Encoding.UTF8.GetBytes(req), true);
-
-            return Ok(TransResponse.BuildSucceedResponse());
-        }
-
-        [HttpPost("wf-resume")]
-        public async Task<IActionResult> WfResume(CancellationToken cancellationToken)
-        {
-            try
-            {
-                if (!_globalTransaction.Exists(wfNameForResume))
-                {
-                    // register again after manual crash by Environment.Exit(0);
-                    _globalTransaction.Register(wfNameForResume, async (wf, data) =>
-                    {
-                        var content = new ByteArrayContent(data);
-                        content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
-
-                        var outClient = wf.NewBranch().NewRequest();
-                        await outClient.PostAsync(_settings.BusiUrl + "/TransOut", content);
-
-                        var inClient = wf.NewBranch().NewRequest();
-                        await inClient.PostAsync(_settings.BusiUrl + "/TransIn", content);
-
-                        return null;
-                    });
-                }
-
-                // prepared call ExecuteByQS
-                using var bodyMemoryStream = new MemoryStream();
-                await Request.Body.CopyToAsync(bodyMemoryStream, cancellationToken);
-                byte[] bytes = bodyMemoryStream.ToArray();
-                string body = Encoding.UTF8.GetString(bytes);
-                _logger.LogDebug($"body: {body}");
-
-                await _globalTransaction.ExecuteByQS(Request.Query, bodyMemoryStream.ToArray());
-
-                return Ok(TransResponse.BuildSucceedResponse());
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Workflow Error");
                 return Ok(TransResponse.BuildFailureResponse());
             }
         }

--- a/src/Dtmworkflow/Workflow.Imp.cs
+++ b/src/Dtmworkflow/Workflow.Imp.cs
@@ -39,7 +39,9 @@ namespace Dtmworkflow
             var status = reply.Transaction.Status;
             if (status == DtmCommon.Constant.StatusSucceed)
             {
-                var sRes = Convert.FromBase64String(reply.Transaction.Result);
+                var sRes = reply.Transaction.Result != null
+                    ? Convert.FromBase64String(reply.Transaction.Result)
+                    : null;
                 return sRes;
             }
             else if (status == DtmCommon.Constant.StatusFailed)


### PR DESCRIPTION
- Fix null value handling for execute again
- Add unit test and sample for different workflow return

execute的返回结果null和empty时候，再用同一gid再次发起均没有返回的`result`的json字段，既byte长度是0不记录也不区分，这些单测和针对Result是null的处理都是建立在务端这feature基础上。