### PR TITLE
refactor: simplify BranchBarrier.Call method, remove overload method with TransactionScopeAsyncFlowOption parameter

### DIFF
--- a/src/DtmCommon/Barrier/BranchBarrier.cs
+++ b/src/DtmCommon/Barrier/BranchBarrier.cs
@@ -122,17 +122,12 @@ namespace DtmCommon
 
         public async Task Call(DbConnection db, Func<Task> busiCall, TransactionScopeOption transactionScope = TransactionScopeOption.Required, IsolationLevel isolationLevel = IsolationLevel.Serializable)
         {
-            await Call(db, busiCall, transactionScope, isolationLevel, TransactionScopeAsyncFlowOption.Suppress);
-        }
-        
-        public async Task Call(DbConnection db, Func<Task> busiCall, TransactionScopeOption transactionScope, IsolationLevel isolationLevel, TransactionScopeAsyncFlowOption transactionScopeAsyncFlowOption)
-        {
             this.BarrierID = this.BarrierID + 1;
             var bid = this.BarrierID.ToString().PadLeft(2, '0');
 
             // check the connection state
             if (db.State != System.Data.ConnectionState.Open) await db.OpenAsync();
-            using (var scope = new TransactionScope(transactionScope, new TransactionOptions { IsolationLevel = isolationLevel }, transactionScopeAsyncFlowOption))
+            using (var scope = new TransactionScope(transactionScope, new TransactionOptions { IsolationLevel = isolationLevel }, TransactionScopeAsyncFlowOption.Enabled))
             {
                 try
                 {


### PR DESCRIPTION
Based on #81  , remove the overload and change the default value to TransactionScopeAsyncFlowOption.Enabled.