### PR TITLE
Bugfix workflow execute dtmfailureexception

### DIFF
--- a/src/Dtmworkflow/Workflow.Imp.cs
+++ b/src/Dtmworkflow/Workflow.Imp.cs
@@ -81,6 +81,9 @@ namespace Dtmworkflow
                 await this.Submit(res, err, default);
             }
 
+            if (err != null)
+                throw err;
+
             return res;
         }
 

--- a/tests/Dtmworkflow.Tests/WorkflowHttpTests.cs
+++ b/tests/Dtmworkflow.Tests/WorkflowHttpTests.cs
@@ -208,7 +208,7 @@ namespace Dtmworkflow.Tests
             wfgt.Register(wfName, handler);
             var req = JsonSerializer.Serialize(new { userId = "1", amount = 30 });
 
-            var res = await wfgt.Execute(wfName, gid, Encoding.UTF8.GetBytes(req), true);
+            var res = await Assert.ThrowsAsync<DtmFailureException>(async () => await wfgt.Execute(wfName, gid, Encoding.UTF8.GetBytes(req), true));
 
             func.Verify(x => x.Invoke(It.IsAny<BranchBarrier>()), Times.Once);
         }

--- a/tests/Dtmworkflow.Tests/WorkflowHttpTests.cs
+++ b/tests/Dtmworkflow.Tests/WorkflowHttpTests.cs
@@ -141,7 +141,7 @@ namespace Dtmworkflow.Tests
         }
 
         [Fact]
-        public async void Execute_Should_Return_Null_When_WfFunc2_ThrowDtmFailureException()
+        public async void Execute_Should_ThrowDtmFailureException_When_WfFunc2_ThrowDtmFailureException()
         {
             var factory = new Mock<IWorkflowFactory>();
             var httpClient = new Mock<IDtmClient>();
@@ -161,7 +161,7 @@ namespace Dtmworkflow.Tests
 
             var wfgt = new WorkflowGlobalTransaction(factory.Object, NullLoggerFactory.Instance);
 
-            var wfName = nameof(Execute_Should_Return_Null_When_WfFunc2_ThrowDtmFailureException);
+            var wfName = nameof(Execute_Should_ThrowDtmFailureException_When_WfFunc2_ThrowDtmFailureException);
             var gid = Guid.NewGuid().ToString("N");
 
             var handler = new Mock<WfFunc2>();
@@ -170,8 +170,7 @@ namespace Dtmworkflow.Tests
             wfgt.Register(wfName, handler.Object);
             var req = JsonSerializer.Serialize(new { userId = "1", amount = 30 });
 
-            var res = await wfgt.Execute(wfName, gid, Encoding.UTF8.GetBytes(req), true);
-            Assert.Null(res);
+            await Assert.ThrowsAsync<DtmFailureException>(async () => await wfgt.Execute(wfName, gid, Encoding.UTF8.GetBytes(req), true));
         }
 
         [Fact]


### PR DESCRIPTION
At the end of the Workflow.Process method, an exception will be thrown if the exception is not null, so that the caller can accurately obtain the exception information.
Adjust the two single tests of WorkflowHttpTests to accommodate exception messages thrown.